### PR TITLE
Fix transactions edit issues

### DIFF
--- a/memory_bank/progress.md
+++ b/memory_bank/progress.md
@@ -31,6 +31,6 @@ pie title Technical Debt Distribution
 | 2.0.0   | 2025-04-01 | Grammy.js migration        |
 
 ## Quality Metrics
-- **Test Coverage**: 68% (API layer)
+- **Test Coverage**: Paused (per directive to prioritize development)
 - **Mean Time to Recovery**: 2.1 hours
 - **Active Issues**: 12 open / 45 closed

--- a/memory_bank/techContext.md
+++ b/memory_bank/techContext.md
@@ -65,10 +65,15 @@ const initialSession: SessionData = {
    DEBUG='bot:*' npm start  # Enable all debug logging
    ```
 
+4. **Testing Protocol**:
+  - **Default Stance**: Suspend all automatic and proactive test-related tasks. Do not write new tests (unit, integration, etc.) or run existing ones unless explicitly requested.
+  - **Rationale**: Prioritize rapid development of functional code.
+  - **Overrides**: This directive is only overridden by a direct user request (e.g., "write unit tests," "how do I test this?").
+
 ## Deployment Architecture
 ```mermaid
 graph TD
-    A[Docker Container] --> B[Node.js Runtime]
+   A[Docker Container] --> B[Node.js Runtime]
     B --> C[Session Storage Volume]
     B --> D[Firefly III API]
     C --> E[Persistent File Storage]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefly-iii-telegram-bot",
   "description": "A Telegram bot for working with Firefly III with a supersonic speed",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "homepage": "https://github.com/cyxou/firefly-iii-telegram-bot#readme",
   "license": "GPL-3.0-or-later",
   "repository": {

--- a/src/composers/transactions/add-transaction.ts
+++ b/src/composers/transactions/add-transaction.ts
@@ -104,7 +104,7 @@ export async function addTransaction(ctx: MyContext) {
         destinationAccountId: defaultDestinationAccount ? defaultDestinationAccount.id.toString() : ''
       })
 
-      ctx.session.currentTransaction = tr
+      ctx.session.newTransaction.id = tr.id
 
       return ctx.reply(
         formatTransaction(ctx, tr),


### PR DESCRIPTION
Hopefully, this fixes the issue of editing one of the older transactions added via the bot. The problem was that when you edited one of the transactions added previously, the bot applied the edits to the latest one added.

I did some testing, and it seems the issue is fixed now.