### PR TITLE
 feat: add basic authorization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ docker run \
   cyxou/firefly-iii-telegram-bot:latest
 ```
 
+#### Restricting Bot Access
+
+To restrict who can use your bot, set the `ALLOWED_TG_USER_IDS` environment variable to a comma-separated list of allowed Telegram user IDs (e.g. `ALLOWED_TG_USER_IDS=123456,987654321`).
+**If this variable is not set, the bot will respond to all users by default.**
+
+By default, if an unauthorized user attempts to use the bot, a log message will be printed to the console with their Telegram ID and a hint to add it to the allowed list. You can disable this logging by setting `DISABLE_UNAUTHORIZED_USER_LOG=true`.
+
+Example with restricted access:
+```shell
+docker run \
+  --rm --it --init --name firefly-bot \
+  --volume `pwd`/sessions:/home/node/app/sessions \
+  --env BOT_TOKEN=<your-bot-token> \
+  --env ALLOWED_TG_USER_IDS=123456,987654321 \
+  cyxou/firefly-iii-telegram-bot:latest
+```
+
 Once the bot is running, navigate to its **Settings** and provide all the
 necessary information to connect it to your Firefly III instance.
 
@@ -60,11 +77,34 @@ For this you need to have NodeJS installed.
  - Clone the repository
  - Install dependencies by running `npm install`
  - Run `export BOT_TOKEN=<your-bot-token>`
+ - (Optional) Restrict access: `export ALLOWED_TG_USER_IDS=123456,987654321`
+   - If not set, the bot will respond to all users.
+ - (Optional) Disable unauthorized user logging: `export DISABLE_UNAUTHORIZED_USER_LOG=true`
  - Run `npm start`
 
 If you'll have certificate errors when trying to connect to Firefly III instance,
 stop the bot, do `export NODE_TLS_REJECT_UNAUTHORIZED=0` in your shell and start the
 bot.
+
+## Access Control & Security
+
+### Restricting Access to Specific Users
+
+You can restrict who can use your bot by setting the `ALLOWED_TG_USER_IDS` environment variable to a comma-separated list of allowed Telegram user IDs. Only users whose IDs are in this list will be able to interact with the bot. If `ALLOWED_TG_USER_IDS` is not set, the bot will respond to all users.
+
+Example:
+```
+ALLOWED_TG_USER_IDS=123456,987654321
+```
+
+### Logging Unauthorized Access Attempts
+
+By default, if an unauthorized user tries to use the bot, a log message will be printed to the console with their Telegram ID and a hint to add it to the allowed list. This helps admins quickly identify and authorize new users.
+
+To disable this logging, set:
+```
+DISABLE_UNAUTHORIZED_USER_LOG=true
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -49,22 +49,6 @@ docker run \
   cyxou/firefly-iii-telegram-bot:latest
 ```
 
-#### Restricting Bot Access
-
-To restrict who can use your bot, set the `ALLOWED_TG_USER_IDS` environment variable to a comma-separated list of allowed Telegram user IDs (e.g. `ALLOWED_TG_USER_IDS=123456,987654321`).
-**If this variable is not set, the bot will respond to all users by default.**
-
-By default, if an unauthorized user attempts to use the bot, a log message will be printed to the console with their Telegram ID and a hint to add it to the allowed list. You can disable this logging by setting `DISABLE_UNAUTHORIZED_USER_LOG=true`.
-
-Example with restricted access:
-```shell
-docker run \
-  --rm --it --init --name firefly-bot \
-  --volume `pwd`/sessions:/home/node/app/sessions \
-  --env BOT_TOKEN=<your-bot-token> \
-  --env ALLOWED_TG_USER_IDS=123456,987654321 \
-  cyxou/firefly-iii-telegram-bot:latest
-```
 
 Once the bot is running, navigate to its **Settings** and provide all the
 necessary information to connect it to your Firefly III instance.
@@ -79,7 +63,6 @@ For this you need to have NodeJS installed.
  - Run `export BOT_TOKEN=<your-bot-token>`
  - (Optional) Restrict access: `export ALLOWED_TG_USER_IDS=123456,987654321`
    - If not set, the bot will respond to all users.
- - (Optional) Disable unauthorized user logging: `export DISABLE_UNAUTHORIZED_USER_LOG=true`
  - Run `npm start`
 
 If you'll have certificate errors when trying to connect to Firefly III instance,
@@ -92,9 +75,14 @@ bot.
 
 You can restrict who can use your bot by setting the `ALLOWED_TG_USER_IDS` environment variable to a comma-separated list of allowed Telegram user IDs. Only users whose IDs are in this list will be able to interact with the bot. If `ALLOWED_TG_USER_IDS` is not set, the bot will respond to all users.
 
-Example:
-```
-ALLOWED_TG_USER_IDS=123456,987654321
+Example with restricted access:
+```shell
+docker run \
+  --rm --it --init --name firefly-bot \
+  --volume `pwd`/sessions:/home/node/app/sessions \
+  --env BOT_TOKEN=<your-bot-token> \
+  --env ALLOWED_TG_USER_IDS=123456,987654321 \
+  cyxou/firefly-iii-telegram-bot:latest
 ```
 
 ### Logging Unauthorized Access Attempts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "firefly-iii-telegram-bot",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firefly-iii-telegram-bot",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@grammyjs/i18n": "0.5.1",
         "@grammyjs/menu": "1.2.1",
+        "@grammyjs/ratelimiter": "1.2.1",
         "@grammyjs/router": "2.0.0",
         "@grammyjs/storage-file": "2.3.2",
         "axios": "1.2.6",
@@ -114,6 +115,12 @@
       "peerDependencies": {
         "grammy": "^1.0.0"
       }
+    },
+    "node_modules/@grammyjs/ratelimiter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/ratelimiter/-/ratelimiter-1.2.1.tgz",
+      "integrity": "sha512-4bmVUBCBnIb2epbDiBLCvvnVjaYg7kDCPR1Ptt6gqoxm5vlD8BjainYv+yjF6221hu2KUv8QAckumDI+6xyGsQ==",
+      "license": "MIT"
     },
     "node_modules/@grammyjs/router": {
       "version": "2.0.0",
@@ -6443,6 +6450,11 @@
       "resolved": "https://registry.npmjs.org/@grammyjs/menu/-/menu-1.2.1.tgz",
       "integrity": "sha512-0LV9A/UukfF46N0ceSqG1RbdCjhvB2u1MNHNkE7eRD3GVlffOBnR+MS2ESE9mSBleT9OjRV6imA7QZ57QBktOQ==",
       "requires": {}
+    },
+    "@grammyjs/ratelimiter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/ratelimiter/-/ratelimiter-1.2.1.tgz",
+      "integrity": "sha512-4bmVUBCBnIb2epbDiBLCvvnVjaYg7kDCPR1Ptt6gqoxm5vlD8BjainYv+yjF6221hu2KUv8QAckumDI+6xyGsQ=="
     },
     "@grammyjs/router": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefly-iii-telegram-bot",
   "description": "A Telegram bot for working with Firefly III with a supersonic speed",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "homepage": "https://github.com/cyxou/firefly-iii-telegram-bot#readme",
   "license": "GPL-3.0-or-later",
   "repository": {
@@ -42,6 +42,7 @@
   "dependencies": {
     "@grammyjs/i18n": "0.5.1",
     "@grammyjs/menu": "1.2.1",
+    "@grammyjs/ratelimiter": "1.2.1",
     "@grammyjs/router": "2.0.0",
     "@grammyjs/storage-file": "2.3.2",
     "axios": "1.2.6",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,15 @@ if (process.env.DEBUG) Debug.enable(process.env.DEBUG)
 dotenv.config()
 
 export default {
-  userId: parseInt(process.env.TG_USER_ID || '', 10),
+  // Logging of unauthorized users is enabled by default; disable if env var is set to 'true'
+  disableUnauthorizedUserLog: process.env.DISABLE_UNAUTHORIZED_USER_LOG === 'true',
+  allowedUserIds: process.env.ALLOWED_TG_USER_IDS
+    ? process.env.ALLOWED_TG_USER_IDS.split(',')
+        .map(id => id.trim())
+        .filter(Boolean)
+        .map(id => Number(id))
+        .filter(id => !isNaN(id))
+    : undefined,
   botToken: process.env.BOT_TOKEN || 'USE_YOUR_REAL_BOT_TOKEN',
   fireflyUrl: process.env.FIREFLY_URL || '',
   fireflyApiUrl: process.env.FIREFLY_API_URL || `${process.env.FIREFLY_URL}/api`,


### PR DESCRIPTION
closes #17

This adds two new environment variables `ALLOWED_TG_USER_IDS` and `LOG_UNAUTHORIZED_USER` in order to control who can use your bot and whether to enable logging of unauthorized access. 

I have also added [rate limiter middleware](https://grammy.dev/plugins/ratelimiter) with default settings to deflect heavy spamming in your bot.