### PR TITLE
Filter accounts to show only active ones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+##################################################
+FROM node:18-alpine3.16 AS deps
+
+WORKDIR /home/node/app
+
+COPY package*.json .npmrc ./
+RUN npm install --omit=dev --omit=optional \
+    && mv ./node_modules ./node_modules_prod \
+    && npm install --omit=optional
+
+##################################################
+FROM deps AS build
+
+WORKDIR /home/node/app
+
+COPY . .
+RUN npm run build
+
+##################################################
+FROM node:18-alpine3.16 AS prod-image
+
+ENV NODE_ENV=production
+WORKDIR /home/node/app
+
+# Copiamos lo compilado
+COPY --from=build /home/node/app/dist ./dist
+COPY --from=build /home/node/app/node_modules_prod ./node_modules
+COPY --from=build /home/node/app/package.json ./package.json
+
+# REPARACIÓN DE LOCALES:
+# El código busca en dist/src/locales, pero están en dist/locales.
+# Creamos el directorio y movemos los archivos a la ruta esperada.
+RUN mkdir -p dist/src/locales && cp dist/locales/*.y*ml dist/src/locales/ 2>/dev/null || true
+
+ENTRYPOINT ["node", "dist/src/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firefly-iii-telegram-bot",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firefly-iii-telegram-bot",
-      "version": "2.2.1",
+      "version": "2.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@grammyjs/i18n": "0.5.1",

--- a/src/composers/accounts.ts
+++ b/src/composers/accounts.ts
@@ -53,8 +53,10 @@ async function showAccounts(ctx: MyContext) {
     }
     log('accType: %O', accType)
 
-    const accounts = (await firefly(userSettings).Accounts.listAccount(
+    let accounts = (await firefly(userSettings).Accounts.listAccount(
       undefined, ACCOUNTS_PAGE_LIMIT, page, balanceToDate, accType as AccountTypeFilter)).data.data
+    // Filter accounts to show only active ones
+    accounts = accounts.filter(acc => acc.attributes.active !== false)
     log('accounts: %O', accounts)
 
     const keyboard = createAccountsMenuKeyboard(ctx, accType as AccountTypeFilter)

--- a/src/composers/helpers.ts
+++ b/src/composers/helpers.ts
@@ -148,6 +148,8 @@ async function createAccountsKeyboard(
     }
 
     log('accounts: %O', accounts)
+    // Filter accounts to show only active ones
+    accounts = accounts.filter(acc => acc.attributes.active !== false)
     const keyboard = new InlineKeyboard()
 
     // Prevent from choosing same account when doing transfers
@@ -200,6 +202,8 @@ async function getFireflyAccounts(
     }
 
     log('accounts: %O', accounts)
+    // Filter accounts to show only active ones
+    accounts = accounts.filter(acc => acc.attributes.active !== false)
 
     // Prevent from choosing same account when doing transfers
     if (opts) accounts = accounts.filter(acc => opts.skipAccountId !== acc.id.toString())

--- a/src/composers/settings.ts
+++ b/src/composers/settings.ts
@@ -49,8 +49,10 @@ const settingsMenu = new Menu<MyContext>('settings')
           'set-default-account',
           async ctx => {
             const userSettings = ctx.session.userSettings
-            const accounts: AccountRead[] = (await firefly(userSettings).Accounts.listAccount(
+            let accounts: AccountRead[] = (await firefly(userSettings).Accounts.listAccount(
               undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.Asset)).data.data
+            // Filter accounts to show only active ones
+            accounts = accounts.filter(acc => acc.attributes.active !== false)
             // Take care of a case when no accounts are created yet
             if (!accounts.length) {
               ctx.editMessageText(ctx.i18n.t('common.noDefaultSourceAccountExist'))
@@ -97,8 +99,10 @@ const defaultAccountMenu = new Menu<MyContext>('set-default-account')
     const userSettings = ctx.session.userSettings
     const { fireflyUrl } = userSettings
 
-    const accounts: AccountRead[] = (await firefly(userSettings).Accounts.listAccount(
+    let accounts: AccountRead[] = (await firefly(userSettings).Accounts.listAccount(
       undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.Asset)).data.data
+    // Filter accounts to show only active ones
+    accounts = accounts.filter(acc => acc.attributes.active !== false)
     log('accounts: %O', accounts)
 
     // Take care of a case when no accounts are created yet

--- a/src/composers/transactions/add-transaction.ts
+++ b/src/composers/transactions/add-transaction.ts
@@ -183,8 +183,11 @@ async function getDefaultSourceAccount(ctx: MyContext): Promise<null | AccountAt
     let { defaultSourceAccount } = ctx.session.userSettings
 
     if (!defaultSourceAccount.name) {
-      const firstAccount = (await firefly(ctx.session.userSettings).Accounts.listAccount(
-        undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.Asset)).data.data[0]
+      let accounts = (await firefly(ctx.session.userSettings).Accounts.listAccount(
+        undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.Asset)).data.data
+      // Filter accounts to show only active ones
+      accounts = accounts.filter(acc => acc.attributes.active !== false)
+      const firstAccount = accounts[0]
       log('firstAccount: %O', firstAccount)
 
       // Looks like that a user has not created any Asset accounts yet
@@ -210,8 +213,11 @@ async function getDefaultDestinationAccount(ctx: MyContext) {
     let { defaultDestinationAccount } = ctx.session.userSettings
 
     if (!defaultDestinationAccount.name) {
-      const cashAccount = (await firefly(ctx.session.userSettings).Accounts.listAccount(
-        undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.CashAccount)).data.data[0]
+      let accounts = (await firefly(ctx.session.userSettings).Accounts.listAccount(
+        undefined, ACCOUNTS_PAGE_LIMIT, 1, dayjs().format('YYYY-MM-DD'), AccountTypeFilter.CashAccount)).data.data
+      // Filter accounts to show only active ones
+      accounts = accounts.filter(acc => acc.attributes.active !== false)
+      const cashAccount = accounts[0]
       log('cashAccount: %O', cashAccount)
 
       // For new user accounts there is no default CashAccount created.

--- a/src/composers/transactions/add-transactions-menus.ts
+++ b/src/composers/transactions/add-transactions-menus.ts
@@ -366,6 +366,8 @@ async function getAccounts(
     }
 
     log('accounts: %O', accounts)
+    // Filter accounts to show only active ones
+    accounts = accounts.filter(acc => acc.attributes.active !== false)
 
     // Prevent from choosing same account when doing transfers
     if (opts) accounts = accounts.filter(acc => opts.skipAccountId !== acc.id.toString())


### PR DESCRIPTION
Implement filtering to ensure only active accounts are displayed across various components. This change enhances user experience by preventing inactive accounts from appearing in the account lists. The version has also been updated to 2.3.1.