### PR TITLE
feat: migrate container registry from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: all
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Put back the git branch into git (Earthly uses it for tagging)
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
 
 env:
-  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  GITHUB_REPO: cyxou/firefly-iii-telegram-bot
+  GHCR_REPO: ghcr.io/cyxou/firefly-iii-telegram-bot
   PR_NUMBER: pr-${{ github.event.number }}
   FORCE_COLOR: 1
 
@@ -42,17 +40,21 @@ jobs:
       - name: Validate PR
         run: |
           earthly --ci --allow-privileged +validatePR \
-            --DOCKERHUB_REPO=$GITHUB_REPO \
-            --DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME \
-            --DOCKERHUB_ACCESS_TOKEN=$DOCKERHUB_TOKEN
+            --GHCR_REPO=$GHCR_REPO \
+            --GHCR_USERNAME=${{ github.actor }} \
+            --GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker Login
-        run: docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN
+      - name: Docker Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build PR Image
         run: |
           earthly --ci --push +build-and-push \
-            --DOCKERHUB_REPO=$GITHUB_REPO \
-            --DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME \
-            --DOCKERHUB_ACCESS_TOKEN=$DOCKERHUB_TOKEN \
+            --GHCR_REPO=$GHCR_REPO \
+            --GHCR_USERNAME=${{ github.actor }} \
+            --GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             --RELEASE_VERSION=$PR_NUMBER

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,7 @@ on:
       - master
 
 env:
-  DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-  GITHUB_REPO: cyxou/firefly-iii-telegram-bot
+  GHCR_REPO: ghcr.io/cyxou/firefly-iii-telegram-bot
   FORCE_COLOR: 1
 
 jobs:
@@ -46,25 +44,21 @@ jobs:
       - name: Earthly version
         run: earthly --version
 
-      - name: Docker Login
-        run: docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_TOKEN
-      
+      - name: Docker Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push docker image
         run: |
           earthly --ci --push +build-and-release \
             --GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            --DOCKERHUB_REPO=$GITHUB_REPO \
-            --DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME \
-            --DOCKERHUB_ACCESS_TOKEN=$DOCKERHUB_TOKEN \
+            --GHCR_REPO=$GHCR_REPO \
+            --GHCR_USERNAME=${{ github.actor }} \
+            --GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             --RELEASE_VERSION=${{ github.ref_name }}
-      
-      - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
-          repository: ${{ env.GITHUB_REPO }}
-          short-description: ${{ github.event.repository.description }}
 
       - name: Send telegram message on release
         uses: appleboy/telegram-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           image: tonistiigi/binfmt:latest
           platforms: all
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Put back the git branch into git (Earthly uses it for tagging)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Build and push docker image
         run: |
           earthly --ci --push +build-and-release \
-            --GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             --GHCR_REPO=$GHCR_REPO \
             --GHCR_USERNAME=${{ github.actor }} \
             --GHCR_TOKEN=${{ secrets.GITHUB_TOKEN }} \

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,6 @@ VERSION 0.7
 ARG --global GHCR_REPO=ghcr.io/cyxou/firefly-iii-telegram-bot
 ARG --global GHCR_USERNAME
 ARG --global GHCR_TOKEN
-ARG --global GITHUB_TOKEN
 ARG --global RELEASE_VERSION=latest
 
 FROM node:20-bullseye
@@ -66,8 +65,9 @@ checkIfTagExist:
     END
 
 release:
-  ARG --required GITHUB_TOKEN
+  ARG --required GHCR_TOKEN
   ARG --required RELEASE_VERSION
+  ENV GITHUB_TOKEN=${GHCR_TOKEN}
   ENV OUT_BASE="./dist"
   ENV REPO="cyxou/firefly-iii-telegram-bot"
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.7
 
-ARG --global DOCKERHUB_REPO=cyxou/firefly-iii-telegram-bot
-ARG --global DOCKERHUB_USERNAME=cyxou
-ARG --global DOCKERHUB_ACCESS_TOKEN
+ARG --global GHCR_REPO=ghcr.io/cyxou/firefly-iii-telegram-bot
+ARG --global GHCR_USERNAME
+ARG --global GHCR_TOKEN
 ARG --global GITHUB_TOKEN
 ARG --global RELEASE_VERSION=latest
 
@@ -52,17 +52,15 @@ buildImage:
 
     CMD ["dist/index.js"]
 
-    SAVE IMAGE --push $DOCKERHUB_REPO:$RELEASE_VERSION
-    SAVE IMAGE --push $DOCKERHUB_REPO:latest
+    SAVE IMAGE --push $GHCR_REPO:$RELEASE_VERSION
+    SAVE IMAGE --push $GHCR_REPO:latest
 
 checkIfTagExist:
     FROM earthly/dind
 
-    # We do explicit login here since earthly/dind image does not infer login from the host
-    RUN docker login --username ${DOCKERHUB_USERNAME} \
-        --password ${DOCKERHUB_ACCESS_TOKEN}
+    RUN echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
 
-    IF docker manifest inspect ${DOCKERHUB_REPO}:${RELEASE_VERSION} > /dev/null
+    IF docker manifest inspect ${GHCR_REPO}:${RELEASE_VERSION} > /dev/null
         RUN echo "👷 Docker image with tag ${RELEASE_VERSION} already exists! You should not override it. Please increment the app version number accordingly. Exiting..." \
             && exit 1
     END

--- a/Earthfile
+++ b/Earthfile
@@ -10,7 +10,7 @@ FROM node:20-bullseye
 WORKDIR /home/node/app
 
 build-and-release:
-    BUILD --platform=linux/amd64 --platform=linux/arm +buildImage
+    BUILD --platform=linux/amd64 --platform=linux/arm +buildImage --TAG_LATEST=true
     BUILD +release
 
 build-and-push:
@@ -46,13 +46,16 @@ runTests:
     RUN echo "😞 No tests yet..."
 
 buildImage:
+    ARG TAG_LATEST=false
     COPY +buildDist/dist ./dist
     COPY +deps/node_modules_prod ./node_modules
 
     CMD ["dist/index.js"]
 
     SAVE IMAGE --push $GHCR_REPO:$RELEASE_VERSION
-    SAVE IMAGE --push $GHCR_REPO:latest
+    IF [ "$TAG_LATEST" = "true" ]
+        SAVE IMAGE --push $GHCR_REPO:latest
+    END
 
 checkIfTagExist:
     FROM earthly/dind

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run \
   --rm --it --init --name firefly-bot \
   --volume `pwd`/sessions:/home/node/app/sessions \
   --env BOT_TOKEN=<your-bot-token> \
-  cyxou/firefly-iii-telegram-bot:latest
+  ghcr.io/cyxou/firefly-iii-telegram-bot:latest
 ```
 
 You may also provide BOT_TOKEN via the .env file. For this just rename the
@@ -46,7 +46,7 @@ docker run \
   --rm --it --init --name firefly-bot \
   --volume `pwd`/sessions:/home/node/app/sessions \
   --env-file .env \
-  cyxou/firefly-iii-telegram-bot:latest
+  ghcr.io/cyxou/firefly-iii-telegram-bot:latest
 ```
 
 
@@ -82,7 +82,7 @@ docker run \
   --volume `pwd`/sessions:/home/node/app/sessions \
   --env BOT_TOKEN=<your-bot-token> \
   --env ALLOWED_TG_USER_IDS=123456,987654321 \
-  cyxou/firefly-iii-telegram-bot:latest
+  ghcr.io/cyxou/firefly-iii-telegram-bot:latest
 ```
 
 ### Logging Unauthorized Access Attempts


### PR DESCRIPTION
Switch all CI/CD pipelines and build configs to push images to GitHub Container Registry (ghcr.io) instead of Docker Hub. Use docker/login-action@v4 for GHCR authentication and remove the Docker Hub description step. Update README examples accordingly.

---

> 📣 **All Docker images are now hosted on GitHub Container Registry (GHCR)!**
>
> Previous Docker Hub images (`cyxou/firefly-iii-telegram-bot`) are deprecated.
> Please update your pull commands to use the new registry:
>
> ```
> docker pull ghcr.io/cyxou/firefly-iii-telegram-bot:latest
> ```